### PR TITLE
Implements AddRecordCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddRecordCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRecordCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.Record;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * Adds a new record into the record list of the current person whose record list is being displayed.
+ * Record Date provided must be formatted in dd-MM-yyyy HHmm.
+ */
+public class AddRecordCommand extends Command {
+
+    public static final String COMMAND_WORD = "addR";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a new record to the list of records.\n"
+            + "Parameters: "
+            + PREFIX_DATE + "Record Date "
+            + PREFIX_RECORD + "Record Content\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_DATE + "31-10-2022 1430 (must be formatted in dd-MM-yyyy HHmm)"
+            + PREFIX_RECORD + "suffers from common cold";
+
+    public static final String MESSAGE_SUCCESS = "New record added: %1$s";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This record already exists in the record list";
+
+    private final Record toAdd;
+
+    /**
+     * Creates an AddRecordCommand to add the specified {@code Record}
+     */
+    public AddRecordCommand(Record record) {
+        requireNonNull(record);
+        toAdd = record;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, toAdd),
+                false, false, true);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddRecordCommand // instanceof handles nulls
+                && toAdd.equals(((AddRecordCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddRecordCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRecordCommand.java
@@ -1,11 +1,12 @@
 package seedu.address.logic.commands;
 
-import seedu.address.commons.core.Messages;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECORD;
+
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Record;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
 
 /**
  * Adds a new record into the record list of the current person whose record list is being displayed.
@@ -37,8 +38,14 @@ public class AddRecordCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.hasRecord(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.addRecord(toAdd);
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, toAdd),
                 false, false, true);

--- a/src/main/java/seedu/address/logic/parser/AddRecordCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddRecordCommandParser.java
@@ -1,13 +1,14 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.AddRecordCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Record;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECORD;
 
 import java.util.stream.Stream;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import seedu.address.logic.commands.AddRecordCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Record;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -17,23 +18,24 @@ public class AddRecordCommandParser implements Parser<AddRecordCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the AddRecordCommand
      * and returns a AddRecordCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddRecordCommand parse(String args) throws ParseException {
-            ArgumentMultimap argMultimap =
-                    ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_RECORD);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_RECORD);
 
-            if (!arePrefixesPresent(argMultimap, PREFIX_DATE, PREFIX_RECORD)
-                    || !argMultimap.getPreamble().isEmpty()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRecordCommand.MESSAGE_USAGE));
-            }
+        if (!arePrefixesPresent(argMultimap, PREFIX_DATE, PREFIX_RECORD)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRecordCommand.MESSAGE_USAGE));
+        }
 
-            String recordDate = argMultimap.getValue(PREFIX_DATE).get();
-            String recordData = argMultimap.getValue(PREFIX_RECORD).get();
+        String recordDate = argMultimap.getValue(PREFIX_DATE).get();
+        String recordData = argMultimap.getValue(PREFIX_RECORD).get();
 
-            Record record = ParserUtil.parseRecord(recordDate, recordData);
+        Record record = ParserUtil.parseRecord(recordDate, recordData);
 
-            return new AddRecordCommand(record);
+        return new AddRecordCommand(record);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddRecordCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddRecordCommandParser.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.AddRecordCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Record;
+
+import java.util.stream.Stream;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class AddRecordCommandParser implements Parser<AddRecordCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddRecordCommand
+     * and returns a AddRecordCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddRecordCommand parse(String args) throws ParseException {
+            ArgumentMultimap argMultimap =
+                    ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_RECORD);
+
+            if (!arePrefixesPresent(argMultimap, PREFIX_DATE, PREFIX_RECORD)
+                    || !argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRecordCommand.MESSAGE_USAGE));
+            }
+
+            String recordDate = argMultimap.getValue(PREFIX_DATE).get();
+            String recordData = argMultimap.getValue(PREFIX_RECORD).get();
+
+            Record record = ParserUtil.parseRecord(recordDate, recordData);
+
+            return new AddRecordCommand(record);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,16 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.FindRecordCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -71,6 +62,9 @@ public class AddressBookParser {
 
         case FindRecordCommand.COMMAND_WORD:
             return new FindRecordCommandParser().parse(arguments);
+
+        case AddRecordCommand.COMMAND_WORD:
+            return new AddRecordCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,7 +6,17 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddRecordCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindRecordCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_RECORD = new Prefix("r/");
+    public static final Prefix PREFIX_DATE = new Prefix("d/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -13,6 +15,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Record;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -120,5 +123,21 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String recordDate} and {@code String recordData} into a {@code Record}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given inputs is invalid.
+     */
+    public static Record parseRecord(String recordDate, String recordData) throws ParseException {
+        requireAllNonNull(recordDate, recordData);
+        String trimmedDate = recordDate.trim();
+        String trimmedData = recordData.trim();
+        if (!Record.isValidDate(trimmedDate)) {
+            throw new ParseException(Record.MESSAGE_CONSTRAINTS);
+        }
+        return new Record(trimmedDate, trimmedData);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -77,6 +77,17 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Returns true if a record with the same identity as {@code record} exists in the record list.
+     */
+    boolean hasRecord(Record record);
+
+    /**
+     * Adds the given record.
+     * {@code person} must not already exist in the record list.
+     */
+    void addRecord(Record record);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -128,10 +128,12 @@ public class ModelManager implements Model {
 
     //=========== Record List ================================================================================
 
+    @Override
     public void addRecord(Record record) {
         personWithRecords.addRecord(record);
     }
 
+    @Override
     public boolean hasRecord(Record record) {
         return personWithRecords.hasRecord(record);
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,6 +24,7 @@ public class ModelManager implements Model {
 
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
+    private final Person personWithRecords; // Person whose records are being displayed (if any)
     private final FilteredList<Person> filteredPersons;
     private FilteredList<Record> filteredRecords;
 
@@ -40,6 +41,7 @@ public class ModelManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
+        this.personWithRecords = null;
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
 
         //stub, replace with commented out code once recordList is functional
@@ -122,6 +124,16 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    //=========== Record List ================================================================================
+
+    public void addRecord(Record record) {
+        personWithRecords.addRecord(record);
+    }
+
+    public boolean hasRecord(Record record) {
+        return personWithRecords.hasRecord(record);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -3,9 +3,11 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 
-import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,12 +1,11 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
+import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -23,19 +22,19 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
-    private final RecordList recordList;
+    private final RecordList records;
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, RecordList recordList) {
+    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, RecordList records) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
-        this.recordList = recordList;
+        this.records = records;
     }
 
     public Name getName() {
@@ -55,7 +54,7 @@ public class Person {
     }
 
     public RecordList getRecordList() {
-        return recordList;
+        return records;
     }
 
     /**
@@ -79,10 +78,38 @@ public class Person {
                 && otherPerson.getName().equals(getName());
     }
 
+    //======= Record List ========================================
+
+    /**
+     * Replaces the contents of the record list with {@code records}.
+     * {@code records} must not contain duplicate persons.
+     */
+    public void setRecords(RecordList records) {
+        this.records.setRecordList(records);
+    }
+
+    /**
+     * Returns true if a record with the same identity as {@code record} exists in the record list.
+     */
+    public boolean hasRecord(Record record) {
+        requireNonNull(record);
+        return records.contains(record);
+    }
+
+    /**
+     * Adds a record to the record list.
+     * The record must not already exist in the record list.
+     */
+    public void addRecord(Record r) {
+        records.add(r);
+    }
+
     /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */
+
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/address/model/person/RecordList.java
+++ b/src/main/java/seedu/address/model/person/RecordList.java
@@ -1,9 +1,9 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Represents a record list in the address book.

--- a/src/main/java/seedu/address/model/person/RecordList.java
+++ b/src/main/java/seedu/address/model/person/RecordList.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents a record list in the address book.
  */
@@ -28,6 +30,11 @@ public class RecordList {
         return internalUnmodifiableRecordList;
     }
 
+    public void setRecordList(RecordList replacement) {
+        requireNonNull(replacement);
+        recordList.setAll(replacement.recordList);
+    }
+
     /**
      * Getter for size of list.
      *
@@ -37,6 +44,7 @@ public class RecordList {
         return this.recordList.size();
     }
 
+    // TODO IMPLEMENT THIS
     @Override
     public String toString() {
         return "Number of Records: " + recordList.size();
@@ -56,6 +64,14 @@ public class RecordList {
      */
     public void add(Record record) {
         recordList.add(record);
+    }
+
+    /**
+     * Returns true if the list contains an equivalent record as the given argument.
+     */
+    public boolean contains(Record toCheck) {
+        requireNonNull(toCheck);
+        return recordList.stream().anyMatch(toCheck::equals);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/RecordList.java
+++ b/src/main/java/seedu/address/model/person/RecordList.java
@@ -69,7 +69,7 @@ public class RecordList {
                 || (other instanceof RecordList // instanceof handles nulls
                 && recordList.equals(((RecordList) other).recordList)); // state check
     }
-    
+
     @Override
     public int hashCode() {
         return recordList.hashCode();

--- a/src/main/java/seedu/address/ui/RecordListPanel.java
+++ b/src/main/java/seedu/address/ui/RecordListPanel.java
@@ -26,13 +26,13 @@ public class RecordListPanel extends UiPart<Region> {
     public RecordListPanel(ObservableList<Record> recordList) {
         super(FXML);
         recordListView.setItems(recordList);
-        recordListView.setCellFactory(listView -> new recordListViewCell());
+        recordListView.setCellFactory(listView -> new RecordListViewCell());
     }
 
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Record} using a {@code RecordCard}.
      */
-    class recordListViewCell extends ListCell<Record> {
+    class RecordListViewCell extends ListCell<Record> {
         @Override
         protected void updateItem(Record record, boolean empty) {
             super.updateItem(record, empty);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -140,6 +140,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasRecord(Record record) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addRecord(Record record) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
- Implements basic execution path for adding records to a person's record list.
- Adds `AddRecordCommand` and `AddRecordCommandParser` classes, 
- Adds prefixes for date and record inputs in `CLISyntax` class.
- Adds parseRecord function in `ParserUtil` class.
- Adds `personWithRecords` field in `ModelManager` to encapsulate the current person whose records are being displayed/processed.

**TODO:**
- Implement default state for `personWithRecords` field in `ModelManager` (currently set to NULL), when non-record dependent commands are executed. Consider creating class to represent a default person or placeholder person.
- Implement functionality to change / set the current `personWithRecords` in `ModelManager` (limited by `final` modifier).
- Add tests for `AddRecordCommand` 

fixes #40 