### PR TITLE
Add Test Classes for AddRecordCommand

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,6 +10,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_RECORDS_LISTED_OVERVIEW = "%1$d records listed!";
+    public static final String MESSAGE_INVALID_RECORD_DATA_FORMAT = "Record data cannot be empty!";
     public static final String MESSAGE_INVALID_DATE_FORMAT =
             "Invalid date format! \n Please use the format dd-MM-yyyy HHmm!";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -82,7 +82,6 @@ public class AddressBookParser {
         case FindRecordCommand.COMMAND_WORD:
             return new FindRecordCommandParser().parse(arguments);
 
-
         case ClearRecordCommand.COMMAND_WORD:
             return new ClearRecordCommand();
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -134,9 +135,15 @@ public class ParserUtil {
         requireAllNonNull(recordDate, recordData);
         String trimmedDate = recordDate.trim();
         String trimmedData = recordData.trim();
+
         if (!Record.isValidDate(trimmedDate)) {
-            throw new ParseException(Record.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Messages.MESSAGE_INVALID_DATE_FORMAT);
         }
+
+        if (!Record.isValidRecordData(trimmedData)) {
+            throw new ParseException(Messages.MESSAGE_INVALID_RECORD_DATA_FORMAT);
+        }
+
         return new Record(trimmedDate, trimmedData);
     }
 }

--- a/src/main/java/seedu/address/model/person/Record.java
+++ b/src/main/java/seedu/address/model/person/Record.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATE_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_RECORD_DATA_FORMAT;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDateTime;
@@ -14,12 +15,9 @@ import java.time.format.DateTimeParseException;
  */
 public class Record {
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
-    public static final String MESSAGE_CONSTRAINTS = "Record date should be in the following format: "
-            + "DD-MM-YYYY HHmm";
     /* Data Fields */
     public final String record;
     private final LocalDateTime recordDate;
-
 
     /**
      * Constructs a record.
@@ -31,8 +29,8 @@ public class Record {
         requireNonNull(recordDate);
         requireNonNull(record);
         checkArgument(isValidDate(recordDate), MESSAGE_INVALID_DATE_FORMAT);
+        checkArgument(isValidRecordData(record), MESSAGE_INVALID_RECORD_DATA_FORMAT);
         this.recordDate = LocalDateTime.parse(recordDate, DATE_FORMAT);
-        // record field not checked since any record input can be valid.
         this.record = record;
     }
 
@@ -49,6 +47,13 @@ public class Record {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Returns true if a given string is valid record data.
+     */
+    public static boolean isValidRecordData(String test) {
+        return !test.isBlank();
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedRecord.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRecord.java
@@ -3,6 +3,7 @@ package seedu.address.storage;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Record;
 import seedu.address.model.tag.Tag;
@@ -41,7 +42,11 @@ class JsonAdaptedRecord {
      */
     public Record toModelType() throws IllegalValueException {
         if (!Record.isValidDate(recordDate)) {
-            throw new IllegalValueException(Record.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Messages.MESSAGE_INVALID_DATE_FORMAT);
+        }
+
+        if (!Record.isValidRecordData(record)) {
+            throw new IllegalValueException(Messages.MESSAGE_INVALID_RECORD_DATA_FORMAT);
         }
         return new Record(recordDate, record);
     }

--- a/src/test/java/seedu/address/logic/commands/AddRecordCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRecordCommandTest.java
@@ -1,90 +1,71 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.core.Messages.MESSAGE_RECORDS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.AddRecordCommand.MESSAGE_DUPLICATE_RECORD;
+import static seedu.address.logic.commands.AddRecordCommand.MESSAGE_SUCCESS;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.RECORD1;
+import static seedu.address.testutil.TypicalPersons.RECORD2;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.RecordContainsKeywordsPredicate;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code FindRecordCommand}.
+ * Contains integration tests (interaction with the Model) for {@code AddRecordCommand}.
  */
-public class FindRecordCommandTest {
+public class AddRecordCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void equals() {
-        RecordContainsKeywordsPredicate firstPredicate =
-                new RecordContainsKeywordsPredicate(Collections.singletonList("Covid-19"));
-        RecordContainsKeywordsPredicate secondPredicate =
-                new RecordContainsKeywordsPredicate(Collections.singletonList("cold"));
-
-        FindRecordCommand findFirstCommand = new FindRecordCommand(firstPredicate);
-        FindRecordCommand findSecondCommand = new FindRecordCommand(secondPredicate);
+        AddRecordCommand addFirstCommand = new AddRecordCommand(RECORD1);
+        AddRecordCommand addSecondCommand = new AddRecordCommand(RECORD2);
 
         // same object -> returns true
-        assertTrue(findFirstCommand.equals(findFirstCommand));
+        assertTrue(addFirstCommand.equals(addFirstCommand));
 
         // same values -> returns true
-        FindRecordCommand findFirstCommandCopy = new FindRecordCommand(firstPredicate);
-        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+        AddRecordCommand addFirstCommandCopy = new AddRecordCommand(RECORD1);
+        assertTrue(addFirstCommand.equals(addFirstCommandCopy));
 
         // different types -> returns false
-        assertFalse(findFirstCommand.equals(1));
+        assertFalse(addFirstCommand.equals(1));
 
         // null -> returns false
-        assertFalse(findFirstCommand.equals(null));
+        assertFalse(addFirstCommand.equals(null));
 
         // different person -> returns false
-        assertFalse(findFirstCommand.equals(findSecondCommand));
+        assertFalse(addFirstCommand.equals(addSecondCommand));
     }
 
     @Test
-    public void execute_zeroKeywords_noRecordFound() {
-        prepareModel();
-        String expectedMessage = String.format(MESSAGE_RECORDS_LISTED_OVERVIEW, 0);
-        RecordContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindRecordCommand command = new FindRecordCommand(predicate);
-        expectedModel.updateFilteredRecordList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredRecordList());
-    }
-
-    /*
-    @Test
-    public void execute_multipleKeywords_multipleRecordsFound() {
-        prepareModel();
-        String expectedMessage = String.format(MESSAGE_RECORDS_LISTED_OVERVIEW, 3);
-        RecordContainsKeywordsPredicate predicate = preparePredicate("Cold Covid-19 SARS");
-        FindRecordCommand command = new FindRecordCommand(predicate);
-        expectedModel.updateFilteredRecordList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(RECORD1, RECORD2, RECORD3), model.getFilteredRecordList());
-    }
-    */
-
-    /**
-     * Parses {@code userInput} into a {@code RecordContainsKeywordsPredicate}.
-     */
-    private RecordContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new RecordContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
-    }
-
-    private void prepareModel() {
-        model.setFilteredRecordList(BENSON);
+    public void execute_duplicateRecord_exceptionThrown() {
+        model.setFilteredRecordList(GEORGE); // Typical Person with existing RECORD1 in record list
         model.setRecordListDisplayed(true);
+
+        AddRecordCommand addRecordCommand = new AddRecordCommand(RECORD1);
+
+        assertCommandFailure(addRecordCommand, model, MESSAGE_DUPLICATE_RECORD);
+    }
+
+    @Test
+    public void execute_addRecord_success() {
+        model.setFilteredRecordList(GEORGE); // Typical Person with existing RECORD1 in record list
+        model.setRecordListDisplayed(true);
+
+        expectedModel.setFilteredRecordList(GEORGE); // Typical Person with existing RECORD1 in record list
+        expectedModel.setRecordListDisplayed(true);
+
+        AddRecordCommand addRecordCommand = new AddRecordCommand(RECORD2);
+
+        assertCommandSuccess(addRecordCommand, model, String.format(MESSAGE_SUCCESS, RECORD2), expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddRecordCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRecordCommandTest.java
@@ -1,0 +1,90 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_RECORDS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.RecordContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindRecordCommand}.
+ */
+public class FindRecordCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        RecordContainsKeywordsPredicate firstPredicate =
+                new RecordContainsKeywordsPredicate(Collections.singletonList("Covid-19"));
+        RecordContainsKeywordsPredicate secondPredicate =
+                new RecordContainsKeywordsPredicate(Collections.singletonList("cold"));
+
+        FindRecordCommand findFirstCommand = new FindRecordCommand(firstPredicate);
+        FindRecordCommand findSecondCommand = new FindRecordCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstCommand.equals(findFirstCommand));
+
+        // same values -> returns true
+        FindRecordCommand findFirstCommandCopy = new FindRecordCommand(firstPredicate);
+        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noRecordFound() {
+        prepareModel();
+        String expectedMessage = String.format(MESSAGE_RECORDS_LISTED_OVERVIEW, 0);
+        RecordContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindRecordCommand command = new FindRecordCommand(predicate);
+        expectedModel.updateFilteredRecordList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredRecordList());
+    }
+
+    /*
+    @Test
+    public void execute_multipleKeywords_multipleRecordsFound() {
+        prepareModel();
+        String expectedMessage = String.format(MESSAGE_RECORDS_LISTED_OVERVIEW, 3);
+        RecordContainsKeywordsPredicate predicate = preparePredicate("Cold Covid-19 SARS");
+        FindRecordCommand command = new FindRecordCommand(predicate);
+        expectedModel.updateFilteredRecordList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(RECORD1, RECORD2, RECORD3), model.getFilteredRecordList());
+    }
+    */
+
+    /**
+     * Parses {@code userInput} into a {@code RecordContainsKeywordsPredicate}.
+     */
+    private RecordContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new RecordContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    private void prepareModel() {
+        model.setFilteredRecordList(BENSON);
+        model.setRecordListDisplayed(true);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,9 +3,11 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -36,6 +38,8 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_RECORD_DATE = "02-03-2024 1230";
+    public static final String VALID_RECORD_DATA = "fever";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -47,12 +51,16 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String RECORD_DATE_DESC = " " + PREFIX_DATE + VALID_RECORD_DATE;
+    public static final String RECORD_DATA_DESC = " " + PREFIX_RECORD + VALID_RECORD_DATA;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_RECORD_DATE_DESC = " " + PREFIX_DATE + "99-99-99"; // Incorrect date format
+    public static final String INVALID_RECORD_DATA_DESC = " " + PREFIX_RECORD + " "; // Cannot be blank
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/AddRecordCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddRecordCommandParserTest.java
@@ -1,35 +1,51 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATE_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_RECORD_DATA_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_RECORD_DATA_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_RECORD_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.RECORD_DATA_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.RECORD_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_DATA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_DATE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.FindRecordCommand;
-import seedu.address.model.person.RecordContainsKeywordsPredicate;
+import seedu.address.logic.commands.AddRecordCommand;
+import seedu.address.model.person.Record;
 
-public class FindRecordCommandParserTest {
+public class AddRecordCommandParserTest {
 
-    private FindRecordCommandParser parser = new FindRecordCommandParser();
+    private AddRecordCommandParser parser = new AddRecordCommandParser();
 
     @Test
     public void parse_emptyArg_throwsParseException() {
         assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                FindRecordCommand.MESSAGE_USAGE));
+                AddRecordCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_validArgs_returnsFindRecordCommand() {
-        // no leading and trailing whitespaces
-        FindRecordCommand expectedFindRecordCommand =
-                new FindRecordCommand(new RecordContainsKeywordsPredicate(Arrays.asList("flu", "cold")));
-        assertParseSuccess(parser, "flu cold", expectedFindRecordCommand);
+    public void parse_validArgs_success() {
+        Record expectedRecord = new Record(VALID_RECORD_DATE, VALID_RECORD_DATA);
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n flu \n \t cold  \t", expectedFindRecordCommand);
+        assertParseSuccess(parser, RECORD_DATE_DESC + RECORD_DATA_DESC, new AddRecordCommand(expectedRecord));
     }
+
+    @Test
+    public void parse_invalidArgs_parseExceptionThrown() {
+        String expectedMessageInvalidDate = MESSAGE_INVALID_DATE_FORMAT;
+        String expectedMessageInvalidRecordData = MESSAGE_INVALID_RECORD_DATA_FORMAT;
+
+        // Invalid data
+        assertParseFailure(parser, RECORD_DATE_DESC + INVALID_RECORD_DATA_DESC,
+                expectedMessageInvalidRecordData);
+
+        // Invalid date
+        assertParseFailure(parser, INVALID_RECORD_DATE_DESC + RECORD_DATA_DESC, expectedMessageInvalidDate);
+    }
+
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddRecordCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddRecordCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindRecordCommand;
+import seedu.address.model.person.RecordContainsKeywordsPredicate;
+
+public class FindRecordCommandParserTest {
+
+    private FindRecordCommandParser parser = new FindRecordCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindRecordCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindRecordCommand() {
+        // no leading and trailing whitespaces
+        FindRecordCommand expectedFindRecordCommand =
+                new FindRecordCommand(new RecordContainsKeywordsPredicate(Arrays.asList("flu", "cold")));
+        assertParseSuccess(parser, "flu cold", expectedFindRecordCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n flu \n \t cold  \t", expectedFindRecordCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Record;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
@@ -26,6 +27,8 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_RECORD_DATE = "99-99-99";
+    private static final String INVALID_RECORD_DATA = " ";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -33,6 +36,8 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_RECORD_DATE = "02-03-2024 1230";
+    private static final String VALID_RECORD_DATA = "fever";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -192,5 +197,39 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseRecord_nullRecordDate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseRecord((String) null, VALID_RECORD_DATA));
+    }
+
+    @Test
+    public void parseRecord_nullRecordData_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseRecord(VALID_RECORD_DATE, (String) null));
+    }
+
+    @Test
+    public void parseRecord_invalidRecordDate_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseRecord(INVALID_RECORD_DATE, VALID_RECORD_DATA));
+    }
+
+    @Test
+    public void parseRecord_invalidRecordData_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseRecord(VALID_RECORD_DATE, INVALID_RECORD_DATA));
+    }
+
+    @Test
+    public void parseRecord_validValuesWithoutWhitespace_returnsRecord() throws Exception {
+        Record expectedRecord = new Record(VALID_RECORD_DATE, VALID_RECORD_DATA);
+        assertEquals(expectedRecord, ParserUtil.parseRecord(VALID_RECORD_DATE, VALID_RECORD_DATA));
+    }
+
+    @Test
+    public void parseRecord_validValuesWithWhitespace_returnsTrimmedRecord() throws Exception {
+        String recordDateWithWhitespace = WHITESPACE + VALID_RECORD_DATE + WHITESPACE;
+        String recordDataWithWhitespace = WHITESPACE + VALID_RECORD_DATA + WHITESPACE;
+        Record expectedRecord = new Record(VALID_RECORD_DATE, VALID_RECORD_DATA);
+        assertEquals(expectedRecord, ParserUtil.parseRecord(recordDateWithWhitespace, recordDataWithWhitespace));
     }
 }

--- a/src/test/java/seedu/address/model/person/DisplayedPersonTest.java
+++ b/src/test/java/seedu/address/model/person/DisplayedPersonTest.java
@@ -1,0 +1,2 @@
+package seedu.address.model.person;public class DisplayedPersonTest {
+}

--- a/src/test/java/seedu/address/model/person/DisplayedPersonTest.java
+++ b/src/test/java/seedu/address/model/person/DisplayedPersonTest.java
@@ -1,2 +1,51 @@
-package seedu.address.model.person;public class DisplayedPersonTest {
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Test cases for {@code DisplayedPerson}
+ */
+public class DisplayedPersonTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private DisplayedPerson defaultPerson = new DisplayedPerson(GEORGE);
+
+    @Test
+    public void setDisplayedPerson_nullPerson_nullPointerExceptionThrown() {
+        try {
+            defaultPerson.setDisplayedPerson((Person) null, getTypicalAddressBook());
+            fail(); // should not reach this step
+        } catch (NullPointerException npe) {
+            assert true;
+        }
+    }
+
+    /**
+     * pass if PersonNotFoundException is thrown when attempting to set a {@code Person} not
+     * found in addressbook.
+     */
+    @Test
+    public void setDisplayedPerson_invalidPerson_personNotFoundExceptionThrown() {
+        try {
+            Person invalidPerson = new PersonBuilder().withName("Person")
+                    .withAddress("123, Jurong West Ave 6, #08-111").withEmail("Person@example.com")
+                    .withPhone("12345678")
+                    .build();
+            defaultPerson.setDisplayedPerson(invalidPerson, getTypicalAddressBook());
+            fail(); // should not reach this step
+        } catch (PersonNotFoundException pnfe) {
+            assert true;
+        }
+    }
+
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -11,12 +11,12 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.model.person.Record;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -119,7 +119,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                         VALID_ADDRESS, VALID_TAGS, invalidRecords);
-        String expectedMessage = Record.MESSAGE_CONSTRAINTS;
+        String expectedMessage = Messages.MESSAGE_INVALID_DATE_FORMAT;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -45,7 +45,7 @@ public class TypicalPersons {
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+            .withEmail("anna@example.com").withAddress("4th street").withRecordList(RECORD1).build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")


### PR DESCRIPTION
- Adds the following classes `AddRecordCommandTest`,  `AddRecordCommandParserTest`,  `DisplayedPersonTest`.
- Modifies `Record` class to validate record data inputs to be non-empty, exception thrown otherwise. Dependent classes in  `Storage`, etc have been modified accordingly.
- Adds test cases in `ParserUtilTest` specific to `ParseUtil#parseRecord`. 