### PR TITLE
Add feature where Displayed Record List is always sorted by Date

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -196,7 +196,8 @@ public class ModelManager implements Model {
 
     /**
      * Returns an unmodifiable view of the list of {@code Record} backed by the internal list of
-     * {@code versionedAddressBook}
+     * {@code versionedAddressBook}. List of {@code Record} returned is sorted by Date, in
+     * descending order.
      */
     @Override
     public ObservableList<Record> getFilteredRecordList() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -8,6 +8,7 @@ import static seedu.address.model.person.Person.DEFAULT_NAME;
 import static seedu.address.model.person.Person.DEFAULT_PHONE;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -199,7 +200,7 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Record> getFilteredRecordList() {
-        return filteredRecords;
+        return filteredRecords.sorted(Collections.reverseOrder());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Record.java
+++ b/src/main/java/seedu/address/model/person/Record.java
@@ -13,7 +13,7 @@ import java.time.format.DateTimeParseException;
 /**
  * Represents a single record in the record list of a Person object.
  */
-public class Record {
+public class Record implements Comparable<Record> {
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
     /* Data Fields */
     public final String record;
@@ -63,6 +63,11 @@ public class Record {
      */
     public String getRecordDate() {
         return recordDate.format(DATE_FORMAT);
+    }
+
+    @Override
+    public int compareTo(Record record) {
+        return this.recordDate.compareTo(record.recordDate);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindRecordCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindRecordCommandTest.java
@@ -70,7 +70,7 @@ public class FindRecordCommandTest {
         FindRecordCommand command = new FindRecordCommand(predicate);
         expectedModel.updateFilteredRecordList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(RECORD1, RECORD2, RECORD3), model.getFilteredRecordList());
+        assertEquals(Arrays.asList(RECORD3, RECORD1, RECORD2), model.getFilteredRecordList());
     }
 
 


### PR DESCRIPTION
- Displayed record list of a patient will remain sorted by date, in descending order, after executing commands that manipulate it, e.g. `addR` and `deleteR`.