### PR TITLE
Enhance `rfind` command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,6 +14,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_RECORD_DATA_FORMAT = "Record data cannot be empty!";
     public static final String MESSAGE_INVALID_DATE_FORMAT =
             "Invalid date format! \n Please use the format dd-MM-yyyy HHmm!";
+    public static final String MESSAGE_INVALID_FIND_DATE_FORMAT =
+            "Invalid find date format! \n Please use the format MM-yyyy!";
 
 
 }

--- a/src/main/java/seedu/address/logic/commands/FindRecordCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindRecordCommand.java
@@ -1,11 +1,18 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RECORD;
+
+import java.time.format.DateTimeFormatter;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.record.RecordContainsKeywordsPredicate;
+
+
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -14,11 +21,19 @@ import seedu.address.model.record.RecordContainsKeywordsPredicate;
 public class FindRecordCommand extends Command {
 
     public static final String COMMAND_WORD = "rfind";
+    public static final DateTimeFormatter FIND_DATE_FORMAT = DateTimeFormatter.ofPattern("MM-yyyy");
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all records whose content contains any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " suffers from common cold";
+            + "Parameters: "
+            + "[" + PREFIX_DATE + "Record Date] "
+            + "[" + PREFIX_RECORD + "Record Content] "
+            + "[" + PREFIX_MEDICATION + "Medication] "
+            + "(at least 1 field must be specified)\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_DATE + "10-2011 (must be formatted in MM-yyyy) "
+            + PREFIX_RECORD + "suffers from common cold "
+            + PREFIX_MEDICATION + "Paracetamol";
 
     private final RecordContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,8 +3,12 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.Messages;
@@ -187,5 +191,42 @@ public class ParserUtil {
         }
 
         return medicationSet;
+    }
+
+    /**
+     * Parses {@code String keywords} into a {@code List<String>}.
+     * Leading and trailing whitespaces will be trimmed.
+     */
+    public static List<String> parseKeywords(String keywords) {
+        // currently does not throw error when empty field eg. r/ or m/
+        String trimmedArgs = keywords.trim();
+
+        if (trimmedArgs.isBlank()) {
+            return new ArrayList<>();
+        } else {
+            String[] nameKeywords = trimmedArgs.split("\\s+");
+            return Arrays.asList(nameKeywords);
+        }
+    }
+
+    /**
+     * Parses a {@code List<String> dateToParse} into a {@code Optional<String>}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given inputs is invalid.
+     */
+    public static Optional<String> parseDateKeyword(List<String> dateToParse) throws ParseException {
+        if (dateToParse.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String date = dateToParse.get(0);
+        Boolean matcher = date.matches("^(?=(?:[^-]*-){1}[^-]*$)(?=(?:\\D*\\d){6}\\D*$).*$");
+
+        if (dateToParse.size() == 1 && matcher) {
+            return Optional.of(date);
+        } else {
+            throw new ParseException(Messages.MESSAGE_INVALID_FIND_DATE_FORMAT);
+        }
     }
 }

--- a/src/main/java/seedu/address/model/record/RecordContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/record/RecordContainsKeywordsPredicate.java
@@ -1,6 +1,10 @@
 package seedu.address.model.record;
 
+import static seedu.address.logic.commands.FindRecordCommand.FIND_DATE_FORMAT;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -9,23 +13,47 @@ import seedu.address.commons.util.StringUtil;
  * Tests that a {@code Record}'s {@code record} matches any of the keywords given.
  */
 public class RecordContainsKeywordsPredicate implements Predicate<Record> {
-    private final List<String> keywords;
+    private final List<String> recordKeywords;
+    private final List<String> medicationKeywords;
+    private final Optional<String> dateKeyword;
 
-    public RecordContainsKeywordsPredicate(List<String> keywords) {
-        this.keywords = keywords;
+    public RecordContainsKeywordsPredicate(List<String> recordKeywords) {
+        this(recordKeywords, new ArrayList<>(), Optional.empty());
+    }
+
+    /**
+     * Constructs a {@code RecordContainsKeywordsPredicate} with the specified fields for
+     * rfind commands with multiple input parameters
+     */
+    public RecordContainsKeywordsPredicate(
+            List<String> recordKeywords, List<String> medicationKeywords, Optional<String> dateKeyword) {
+        this.recordKeywords = recordKeywords;
+        this.medicationKeywords = medicationKeywords;
+        this.dateKeyword = dateKeyword;
     }
 
     @Override
     public boolean test(Record record) {
-        return keywords.stream()
+        boolean recordDataMatch = recordKeywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(record.record, keyword));
+
+        boolean medicationMatch = medicationKeywords.stream()
+                .anyMatch(keyword -> record.getMedications().stream()
+                        .anyMatch(meds -> StringUtil.containsWordIgnoreCase(meds.toString(), keyword)));
+
+        String recordDate = record.getRecordDate().format(FIND_DATE_FORMAT);
+        boolean dateMatch = dateKeyword.map(date -> date.equals(recordDate)).orElse(false);
+
+        return dateMatch || medicationMatch || recordDataMatch;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof RecordContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((RecordContainsKeywordsPredicate) other).keywords)); // state check
+                && recordKeywords.equals(((RecordContainsKeywordsPredicate) other).recordKeywords)// state check
+                && medicationKeywords.equals(((RecordContainsKeywordsPredicate) other).medicationKeywords) //state check
+                && dateKeyword.equals(((RecordContainsKeywordsPredicate) other).dateKeyword)); // state check
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -82,7 +82,7 @@ public class AddressBookParserTest {
     public void parseCommand_findR() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindRecordCommand command = (FindRecordCommand) parser.parseCommand(
-                FindRecordCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindRecordCommand.COMMAND_WORD + " r/" + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindRecordCommand(new RecordContainsKeywordsPredicate(keywords)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindRecordCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindRecordCommandParserTest.java
@@ -26,10 +26,10 @@ public class FindRecordCommandParserTest {
         // no leading and trailing whitespaces
         FindRecordCommand expectedFindRecordCommand =
                 new FindRecordCommand(new RecordContainsKeywordsPredicate(Arrays.asList("flu", "cold")));
-        assertParseSuccess(parser, "flu cold", expectedFindRecordCommand);
+        assertParseSuccess(parser, " r/flu cold", expectedFindRecordCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n flu \n \t cold  \t", expectedFindRecordCommand);
+        assertParseSuccess(parser, " r/flu \n \t cold  \t", expectedFindRecordCommand);
     }
 
 }


### PR DESCRIPTION
User is only able to find records that contains record data which matches the input keywords.

Let's add more functionality to the `rfind` command by allowing the use of prefixes to specify the fields to match the keywords to eg.Medications, Record data or Month

Records with a field that matches any keyword in its respective field will be displayed.

**TODO:**
Add more extensive testcases