### PR TITLE
Add a `BackCommand`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/BackCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BackCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_RECORDS;
+
+import seedu.address.model.Model;
+
+/**
+ * Displays all persons or records after a find or rfind command is executed
+ * Keyword matching is case insensitive.
+ */
+public class BackCommand extends Command {
+
+    public static final String COMMAND_WORD = "back";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "Showing full list";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        if (model.isRecordListDisplayed()) {
+            model.updateFilteredRecordList(PREDICATE_SHOW_ALL_RECORDS);
+            return new CommandResult(MESSAGE_SUCCESS, false, false, true);
+        } else {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            return new CommandResult(MESSAGE_SUCCESS);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -10,11 +10,15 @@ public abstract class Command {
 
     protected static final String MESSAGE_RECORD_COMMAND_PREREQUISITE =
             "A person's record list should be displayed before calling record commands\n"
-            + "(Hint: listR)";
+            + "(Hint: rlist)";
     protected static final String MESSAGE_ADDRESS_BOOK_COMMAND_PREREQUISITE =
             "The address book should be displayed before calling address book commands\n"
             + "(Hint: list)";
 
+    protected static final String MESSAGE_LIST_COMMAND_PREREQUISITE =
+            "List should be used to navigate back to the patient list panel from the record list panel.\n"
+                    + "A person's record list should be displayed first before calling the list command.\n"
+                    + "(Hint: Use back to view the unfiltered list )";
     /**
      * Executes the command and returns the result message.
      *

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 /**
@@ -16,8 +17,12 @@ public class ListCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (!model.isRecordListDisplayed()) {
+            throw new CommandException(MESSAGE_LIST_COMMAND_PREREQUISITE);
+        }
 
         // Update model record list display flag
         model.setRecordListDisplayed(false);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 import seedu.address.logic.commands.AddAppointmentCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddRecordCommand;
+import seedu.address.logic.commands.BackCommand;
 import seedu.address.logic.commands.ClearAppointmentCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.ClearRecordCommand;
@@ -69,6 +70,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case BackCommand.COMMAND_WORD:
+            return new BackCommand();
 
         case ListRecordCommand.COMMAND_WORD:
             return new ListRecordCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -242,7 +242,8 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return addressBook.equals(other.addressBook)
                 && userPrefs.equals(other.userPrefs)
-                && filteredPersons.equals(other.filteredPersons);
+                && filteredPersons.equals(other.filteredPersons)
+                && filteredRecords.equals(other.filteredRecords);
     }
 
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -64,8 +64,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        String clearCommand = ClearCommand.COMMAND_WORD;
+        assertCommandSuccess(clearCommand, ClearCommand.MESSAGE_SUCCESS, model);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/BackCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BackCommandTest.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.record.RecordContainsKeywordsPredicate;
+import seedu.address.testutil.TestUtil;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code BackCommand}.
+ */
+public class BackCommandTest {
+    private final String testString = "benson covid-19";
+    @Test
+    public void execute_emptyAddressBook_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        assertCommandSuccess(new BackCommand(), model, BackCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyFilteredPersonList_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model.updateFilteredPersonList(prepareNamePredicate());
+
+        assertCommandSuccess(new BackCommand(), model, BackCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyFilteredRecordList_success() {
+        Model model = TestUtil.prepareModel();
+        Model expectedModel = TestUtil.prepareModel();
+        model.updateFilteredRecordList(prepareRecordPredicate());
+
+        assertCommandSuccess(new BackCommand(), model, BackCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    /**
+     * Returns a {@code NameContainsKeywordsPredicate}.
+     */
+    private NameContainsKeywordsPredicate prepareNamePredicate() {
+        return new NameContainsKeywordsPredicate(Arrays.asList(testString.split("\\s+")));
+    }
+
+    /**
+     * Returns a {@code RecordContainsKeywordsPredicate}.
+     */
+    private RecordContainsKeywordsPredicate prepareRecordPredicate() {
+        return new RecordContainsKeywordsPredicate(Arrays.asList(testString.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditRecordCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditRecordCommandTest.java
@@ -43,6 +43,7 @@ public class EditRecordCommandTest {
 
         String expectedMessage = String.format(EditRecordCommand.MESSAGE_EDIT_RECORD_SUCCESS, editedRecord);
 
+        expectedModel.setRecord(model.getFilteredRecordList().get(indexLastRecord.getZeroBased()), editedRecord);
         assertCommandSuccess(editRecordCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.Command.MESSAGE_LIST_COMMAND_PREREQUISITE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.FIRST_INDEX;
@@ -17,23 +19,33 @@ import seedu.address.model.UserPrefs;
  */
 public class ListCommandTest {
 
-    private Model model;
+    private Model modelShowingRecordList;
+    private Model modelShowingPatientList;
     private Model expectedModel;
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        modelShowingRecordList = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        modelShowingPatientList = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(modelShowingRecordList.getAddressBook(), new UserPrefs());
+
+        modelShowingRecordList.setRecordListDisplayed(true);
+        expectedModel.setRecordListDisplayed(true);
+    }
+
+    @Test
+    public void execute_listWhileRecordListNotDisplayed_throwCommandException() {
+        assertCommandFailure(new ListCommand(), modelShowingPatientList, MESSAGE_LIST_COMMAND_PREREQUISITE);
     }
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), modelShowingRecordList, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showPersonAtIndex(model, FIRST_INDEX);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        showPersonAtIndex(modelShowingRecordList, FIRST_INDEX);
+        assertCommandSuccess(new ListCommand(), modelShowingRecordList, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }


### PR DESCRIPTION
The commands find and rfind causes the gui to display a filtered list. For rfind specifically, returning to the unfiltered record list requires multiple steps and is therefore troublesome.

Let us add a backcommand to allow the user to return to the unfiltered list immediately, making the CLI faster to use.