### PR TITLE
Add date validation for Record and Birthdate

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -39,7 +39,7 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
 
         String appointmentDate = argumentMultimap.getValue(PREFIX_DATE).orElse("");
 
-        if (!Appointment.isValidDate(appointmentDate)) {
+        if (!Appointment.isValidDateFormat(appointmentDate)) {
             throw new ParseException(AddAppointmentCommand.DATE_MISSING);
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddRecordCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddRecordCommandParser.java
@@ -34,7 +34,7 @@ public class AddRecordCommandParser implements Parser<AddRecordCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRecordCommand.MESSAGE_USAGE));
         }
 
-        LocalDateTime recordDate = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        LocalDateTime recordDate = ParserUtil.parseRecordDate(argMultimap.getValue(PREFIX_DATE).get());
         String recordData = ParserUtil.parseRecordData(argMultimap.getValue(PREFIX_RECORD).get());
         Set<Medication> medications = ParserUtil.parseMedications(argMultimap.getAllValues(PREFIX_MEDICATION));
 

--- a/src/main/java/seedu/address/logic/parser/EditRecordCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditRecordCommandParser.java
@@ -43,7 +43,7 @@ public class EditRecordCommandParser implements Parser<EditRecordCommand> {
 
         EditRecordDescriptor editRecordDescriptor = new EditRecordDescriptor();
         if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
-            editRecordDescriptor.setRecordDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
+            editRecordDescriptor.setRecordDate(ParserUtil.parseRecordDate(argMultimap.getValue(PREFIX_DATE).get()));
         }
         if (argMultimap.getValue(PREFIX_RECORD).isPresent()) {
             editRecordDescriptor.setRecord(ParserUtil.parseRecordData(argMultimap.getValue(PREFIX_RECORD).get()));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -68,8 +68,11 @@ public class ParserUtil {
     public static Birthdate parseBirthdate(String birthdate) throws ParseException {
         requireNonNull(birthdate);
         String trimmedBirthdate = birthdate.trim();
-        if (!Birthdate.isValidBirthdate(trimmedBirthdate)) {
-            throw new ParseException(Birthdate.MESSAGE_CONSTRAINTS);
+        if (!Birthdate.isValidDateFormat(trimmedBirthdate)) {
+            throw new ParseException(Birthdate.MESSAGE_INVALID_DATE_FORMAT);
+        }
+        if (Birthdate.isFutureDate(trimmedBirthdate)) {
+            throw new ParseException(Birthdate.MESSAGE_FUTURE_DATE);
         }
         return new Birthdate(trimmedBirthdate);
     }
@@ -167,11 +170,14 @@ public class ParserUtil {
      *
      * @throws ParseException if the given inputs is invalid.
      */
-    public static LocalDateTime parseDate(String recordDate) throws ParseException {
+    public static LocalDateTime parseRecordDate(String recordDate) throws ParseException {
         requireNonNull(recordDate);
         String trimmedDate = recordDate.trim();
-        if (!Record.isValidDate(trimmedDate)) {
-            throw new ParseException(Messages.MESSAGE_INVALID_DATE_FORMAT);
+        if (!Record.isValidDateFormat(trimmedDate)) {
+            throw new ParseException(Record.MESSAGE_INVALID_DATE_FORMAT);
+        }
+        if (Record.isFutureDate(trimmedDate)) {
+            throw new ParseException(Record.MESSAGE_FUTURE_DATE);
         }
         return LocalDateTime.parse(trimmedDate, Record.DATE_FORMAT);
     }

--- a/src/main/java/seedu/address/model/person/Appointment.java
+++ b/src/main/java/seedu/address/model/person/Appointment.java
@@ -25,7 +25,7 @@ public class Appointment {
      */
     private Appointment(String appointmentDate) {
         requireNonNull(appointmentDate);
-        checkArgument(isValidDate(appointmentDate), MESSAGE_INVALID_DATE_FORMAT);
+        checkArgument(isValidDateFormat(appointmentDate), MESSAGE_INVALID_DATE_FORMAT);
         this.appointmentDate = LocalDateTime.parse(appointmentDate, DATE_FORMAT);
     }
 
@@ -37,12 +37,12 @@ public class Appointment {
     }
 
     /**
-     * Returns true if date is valid.
+     * Returns true if the appointment date is in the valid format.
      *
-     * @param testDate Date to be tested.
-     * @return True if valid.
+     * @param testDate Appointment date to be tested.
+     * @return True if the appointment date is in the valid format.
      */
-    public static boolean isValidDate(String testDate) {
+    public static boolean isValidDateFormat(String testDate) {
         try {
             LocalDateTime.parse(testDate, DATE_FORMAT);
         } catch (DateTimeParseException e) {
@@ -58,7 +58,7 @@ public class Appointment {
      * @return True if valid.
      */
     public static boolean isValidAppointment(String test) {
-        return test.equals(NO_APPOINTMENT_SCHEDULED) || isValidDate(test);
+        return test.equals(NO_APPOINTMENT_SCHEDULED) || isValidDateFormat(test);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Birthdate.java
+++ b/src/main/java/seedu/address/model/person/Birthdate.java
@@ -10,14 +10,14 @@ import java.time.format.DateTimeParseException;
 
 /**
  * Represents a Person's birthdate in the address book.
- * Guarantees: immutable; is valid as declared in {@link #isValidBirthdate(String)}
+ * Guarantees: immutable; is valid as declared in {@link #isValidDateFormat(String)}
  */
 public class Birthdate {
 
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
     public static final DateTimeFormatter DISPLAYED_DATE_FORMAT = DateTimeFormatter.ofPattern("d MMM yyyy");
-    public static final String MESSAGE_CONSTRAINTS = "Birthdate has to be of format dd-MM-yyyy, "
-        + "and must not be later than the current date!";
+    public static final String MESSAGE_INVALID_DATE_FORMAT = "Birthdates have to be of format dd-MM-yyyy!";
+    public static final String MESSAGE_FUTURE_DATE = "Birthdates must not be later than the current date!";
     private final LocalDate birthdate;
 
     /**
@@ -27,26 +27,36 @@ public class Birthdate {
      */
     public Birthdate(String birthdate) {
         requireNonNull(birthdate);
-        checkArgument(isValidBirthdate(birthdate), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidDateFormat(birthdate), MESSAGE_INVALID_DATE_FORMAT);
+        checkArgument(!isFutureDate(birthdate), MESSAGE_FUTURE_DATE);
         this.birthdate = LocalDate.parse(birthdate, DATE_FORMAT);
     }
 
     /**
-     * Returns true if the given birthdate is valid.
+     * Returns true if the given birthdate is in the valid format.
      *
      * @param testDate Birthdate to be tested.
-     * @return true when the given birthdate is valid.
+     * @return true when the given birthdate is in the valid format.
      */
-    public static boolean isValidBirthdate(String testDate) {
-        LocalDate birthdate;
+    public static boolean isValidDateFormat(String testDate) {
         try {
-            birthdate = LocalDate.parse(testDate, DATE_FORMAT);
+            LocalDate.parse(testDate, DATE_FORMAT);
         } catch (DateTimeParseException e) {
             return false;
         }
-        LocalDate currDate = LocalDate.now();
+        return true;
+    }
 
-        return !birthdate.isAfter(currDate);
+    /**
+     * Returns true if the given birthdate is after the current date.
+     *
+     * @param testDate Birthdate to be tested.
+     * @return true when the given birthdate is after the current date.
+     */
+    public static boolean isFutureDate(String testDate) {
+        LocalDate birthdate = LocalDate.parse(testDate, DATE_FORMAT);
+        LocalDate currDate = LocalDate.now();
+        return birthdate.isAfter(currDate);
     }
 
     /**

--- a/src/main/java/seedu/address/model/record/Record.java
+++ b/src/main/java/seedu/address/model/record/Record.java
@@ -1,6 +1,5 @@
 package seedu.address.model.record;
 
-
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_RECORD_DATA_FORMAT;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
@@ -13,12 +12,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-
 /**
  * Represents a single record in the record list of a Person object.
  */
 public class Record implements Comparable<Record> {
     public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy HHmm");
+    public static final String MESSAGE_INVALID_DATE_FORMAT = "Record dates have to be of format dd-MM-yyyy HHmm!";
+    public static final String MESSAGE_FUTURE_DATE = "Record dates must not be later than the current date!";
     /* Data Fields */
     public final String record;
     private final LocalDateTime recordDate;
@@ -54,18 +54,30 @@ public class Record implements Comparable<Record> {
     }
 
     /**
-     * Returns true if date is valid.
+     * Returns true if the record date is in the valid format.
      *
      * @param testDate Date to be tested.
-     * @return True if valid.
+     * @return True if the record date is in the valid format.
      */
-    public static boolean isValidDate(String testDate) {
+    public static boolean isValidDateFormat(String testDate) {
         try {
             LocalDateTime.parse(testDate, DATE_FORMAT);
         } catch (DateTimeParseException e) {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Returns true if the record date is after the current date.
+     *
+     * @param testDate Date to be tested.
+     * @return True if the record date is after the current date.
+     */
+    public static boolean isFutureDate(String testDate) {
+        LocalDateTime recordDate = LocalDateTime.parse(testDate, DATE_FORMAT);
+        LocalDateTime currDate = LocalDateTime.now();
+        return recordDate.isAfter(currDate);
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -109,8 +109,11 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     Birthdate.class.getSimpleName()));
         }
-        if (!Birthdate.isValidBirthdate(birthdate)) {
-            throw new IllegalValueException(Birthdate.MESSAGE_CONSTRAINTS);
+        if (!Birthdate.isValidDateFormat(birthdate)) {
+            throw new IllegalValueException(Birthdate.MESSAGE_INVALID_DATE_FORMAT);
+        }
+        if (Birthdate.isFutureDate(birthdate)) {
+            throw new IllegalValueException(Birthdate.MESSAGE_FUTURE_DATE);
         }
         final Birthdate modelBirthdate = new Birthdate(birthdate);
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedRecord.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRecord.java
@@ -63,8 +63,12 @@ class JsonAdaptedRecord {
             recordMedications.add(med.toModelType());
         }
 
-        if (!Record.isValidDate(recordDate)) {
-            throw new IllegalValueException(Messages.MESSAGE_INVALID_DATE_FORMAT);
+        if (!Record.isValidDateFormat(recordDate)) {
+            throw new IllegalValueException(Record.MESSAGE_INVALID_DATE_FORMAT);
+        }
+
+        if (Record.isFutureDate(recordDate)) {
+            throw new IllegalValueException(Record.MESSAGE_FUTURE_DATE);
         }
 
         if (!Record.isValidRecordData(record)) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -45,7 +45,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_ALICE = "123, Jurong West Ave 6, #08-111";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
-    public static final String VALID_RECORD_DATE = "02-03-2024 1230";
+    public static final String VALID_RECORD_DATE = "02-03-2020 1230";
     public static final String VALID_RECORD_DATE_2 = "01-05-2022 1700";
     public static final String VALID_RECORD_DATA = "fever";
     public static final String VALID_RECORD_DATA_2 = "abdominal pain";

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -125,7 +125,7 @@ public class AddCommandParserTest {
 
         // invalid age
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_BIRTHDATE_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Birthdate.MESSAGE_CONSTRAINTS);
+                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Birthdate.MESSAGE_INVALID_DATE_FORMAT);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + BIRTHDATE_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/AddRecordCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddRecordCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_RECORD_DATA_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_RECORD_DATA_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_RECORD_DATE_DESC;
@@ -19,8 +18,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddRecordCommand;
 import seedu.address.model.record.Record;
-
-
 
 public class AddRecordCommandParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/AddRecordCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddRecordCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATE_FORMAT;
+
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_RECORD_DATA_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_RECORD_DATA_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_RECORD_DATE_DESC;
@@ -11,6 +11,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_DATA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_DATE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.model.record.Record.MESSAGE_INVALID_DATE_FORMAT;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/seedu/address/logic/parser/EditRecordCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditRecordCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATE_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_RECORD_DATA_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_RECORD_DATA_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_RECORD_DATE_DESC;
@@ -10,6 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_DATE_2;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.model.record.Record.MESSAGE_INVALID_DATE_FORMAT;
 import static seedu.address.testutil.TypicalIndexes.FIRST_INDEX;
 import static seedu.address.testutil.TypicalIndexes.SECOND_INDEX;
 import static seedu.address.testutil.TypicalIndexes.THIRD_INDEX;

--- a/src/test/java/seedu/address/model/person/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/person/AppointmentTest.java
@@ -21,24 +21,24 @@ class AppointmentTest {
 
     @Test
     public void isValidDate() {
-        assertThrows(NullPointerException.class, () -> Appointment.isValidDate(null)); // null date
+        assertThrows(NullPointerException.class, () -> Appointment.isValidDateFormat(null)); // null date
 
         // invalid dates
-        assertFalse(Appointment.isValidDate("")); // empty string
-        assertFalse(Appointment.isValidDate(" ")); // spaces only
-        assertFalse(Appointment.isValidDate("02022002 2222")); // incorrect date format
-        assertFalse(Appointment.isValidDate("11.11.2001 1100")); // incorrect date format
-        assertFalse(Appointment.isValidDate("2009.09.21 0000")); // incorrect date format
-        assertFalse(Appointment.isValidDate("10 Jul 2022 1000")); // incorrect date format
-        assertFalse(Appointment.isValidDate("12 12 2007 1230")); // incorrect date format
-        assertFalse(Appointment.isValidDate("2004-11-11 1300")); // incorrect date format
-        assertFalse(Appointment.isValidDate("01-01-2001")); // missing time
-        assertFalse(Appointment.isValidDate("01-01-2001 3000")); // invalid time
+        assertFalse(Appointment.isValidDateFormat("")); // empty string
+        assertFalse(Appointment.isValidDateFormat(" ")); // spaces only
+        assertFalse(Appointment.isValidDateFormat("02022002 2222")); // incorrect date format
+        assertFalse(Appointment.isValidDateFormat("11.11.2001 1100")); // incorrect date format
+        assertFalse(Appointment.isValidDateFormat("2009.09.21 0000")); // incorrect date format
+        assertFalse(Appointment.isValidDateFormat("10 Jul 2022 1000")); // incorrect date format
+        assertFalse(Appointment.isValidDateFormat("12 12 2007 1230")); // incorrect date format
+        assertFalse(Appointment.isValidDateFormat("2004-11-11 1300")); // incorrect date format
+        assertFalse(Appointment.isValidDateFormat("01-01-2001")); // missing time
+        assertFalse(Appointment.isValidDateFormat("01-01-2001 3000")); // invalid time
 
         // valid dates
-        assertTrue(Appointment.isValidDate("01-01-2001 1200"));
-        assertTrue(Appointment.isValidDate("12-02-1927 1230"));
-        assertTrue(Appointment.isValidDate("31-12-2003 1300"));
+        assertTrue(Appointment.isValidDateFormat("01-01-2001 1200"));
+        assertTrue(Appointment.isValidDateFormat("12-02-1927 1230"));
+        assertTrue(Appointment.isValidDateFormat("31-12-2003 1300"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/person/AppointmentTest.java
@@ -48,7 +48,7 @@ class AppointmentTest {
 
     @Test
     public void isFutureDate() {
-        assertThrows(NullPointerException.class, () -> Appointment.isValidDate(null)); // null date
+        assertThrows(NullPointerException.class, () -> Appointment.isValidDateFormat(null)); // null date
 
         // invalid dates
         assertFalse(Appointment.isFutureDate(LocalDateTime.now()

--- a/src/test/java/seedu/address/model/person/BirthdateTest.java
+++ b/src/test/java/seedu/address/model/person/BirthdateTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.person.Birthdate.DATE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import org.junit.jupiter.api.Test;
-
 import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
 
 class BirthdateTest {
 

--- a/src/test/java/seedu/address/model/person/BirthdateTest.java
+++ b/src/test/java/seedu/address/model/person/BirthdateTest.java
@@ -3,9 +3,12 @@ package seedu.address.model.person;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.model.person.Birthdate.DATE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
 
 class BirthdateTest {
 
@@ -21,26 +24,35 @@ class BirthdateTest {
     }
 
     @Test
-    void isValidBirthdate() {
+    void isValidDateFormat() {
         // null birthdate
-        assertThrows(NullPointerException.class, () -> Birthdate.isValidBirthdate(null));
+        assertThrows(NullPointerException.class, () -> Birthdate.isValidDateFormat(null));
 
         // invalid birthdate
-        assertFalse(Birthdate.isValidBirthdate("")); // empty string
-        assertFalse(Birthdate.isValidBirthdate(" ")); // spaces only
-        assertFalse(Birthdate.isValidBirthdate("02022002")); // incorrect date format
-        assertFalse(Birthdate.isValidBirthdate("11.11.2001")); // incorrect date format
-        assertFalse(Birthdate.isValidBirthdate("2009.09.21")); // incorrect date format
-        assertFalse(Birthdate.isValidBirthdate("10 Jul 2022")); // incorrect date format
-        assertFalse(Birthdate.isValidBirthdate("12 12 2007")); // incorrect date format
-        assertFalse(Birthdate.isValidBirthdate("2004-11-11")); // incorrect date format
-        assertFalse(Birthdate.isValidBirthdate("01-01-3000")); // incorrect date (after current date)
-        assertFalse(Birthdate.isValidBirthdate("20-12-2095")); // incorrect date (after current date)
+        assertFalse(Birthdate.isValidDateFormat("")); // empty string
+        assertFalse(Birthdate.isValidDateFormat(" ")); // spaces only
+        assertFalse(Birthdate.isValidDateFormat("02022002")); // incorrect date format
+        assertFalse(Birthdate.isValidDateFormat("11.11.2001")); // incorrect date format
+        assertFalse(Birthdate.isValidDateFormat("2009.09.21")); // incorrect date format
+        assertFalse(Birthdate.isValidDateFormat("10 Jul 2022")); // incorrect date format
+        assertFalse(Birthdate.isValidDateFormat("12 12 2007")); // incorrect date format
+        assertFalse(Birthdate.isValidDateFormat("2004-11-11")); // incorrect date format
 
         // valid birthdate
-        assertTrue(Birthdate.isValidBirthdate("01-01-2001"));
-        assertTrue(Birthdate.isValidBirthdate("12-02-1927"));
-        assertTrue(Birthdate.isValidBirthdate("31-12-2003"));
+        assertTrue(Birthdate.isValidDateFormat("01-01-2001"));
+        assertTrue(Birthdate.isValidDateFormat("12-02-1927"));
+        assertTrue(Birthdate.isValidDateFormat("31-12-2003"));
+    }
+
+    @Test
+    void isFutureDate() {
+        assertTrue(Birthdate.isFutureDate(LocalDate.now().plusYears(10).format(DATE_FORMAT)));
+        assertTrue(Birthdate.isFutureDate(LocalDate.now().plusDays(1).format(DATE_FORMAT)));
+        assertTrue(Birthdate.isFutureDate(LocalDate.now().plusMonths(1).format(DATE_FORMAT)));
+
+        assertFalse(Birthdate.isFutureDate(LocalDate.now().minusYears(6).format(DATE_FORMAT)));
+        assertFalse(Birthdate.isFutureDate(LocalDate.now().minusDays(1).format(DATE_FORMAT)));
+        assertFalse(Birthdate.isFutureDate(LocalDate.now().minusMonths(1).format(DATE_FORMAT)));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/record/RecordTest.java
+++ b/src/test/java/seedu/address/model/record/RecordTest.java
@@ -10,11 +10,11 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.RECORD1;
 import static seedu.address.testutil.TypicalPersons.RECORD2;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.RecordBuilder;
-
-import java.time.LocalDateTime;
 
 public class RecordTest {
 

--- a/src/test/java/seedu/address/model/record/RecordTest.java
+++ b/src/test/java/seedu/address/model/record/RecordTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_DATA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RECORD_MEDICATION;
+import static seedu.address.model.record.Record.DATE_FORMAT;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.RECORD1;
 import static seedu.address.testutil.TypicalPersons.RECORD2;
 
@@ -12,9 +14,42 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.RecordBuilder;
 
-
+import java.time.LocalDateTime;
 
 public class RecordTest {
+
+    @Test
+    public void isValidDateFormat() {
+        assertThrows(NullPointerException.class, () -> Record.isValidDateFormat(null)); // null date
+
+        // invalid dates
+        assertFalse(Record.isValidDateFormat("")); // empty string
+        assertFalse(Record.isValidDateFormat(" ")); // spaces only
+        assertFalse(Record.isValidDateFormat("02022002 2222")); // incorrect date format
+        assertFalse(Record.isValidDateFormat("11.11.2001 1100")); // incorrect date format
+        assertFalse(Record.isValidDateFormat("2009.09.21 0000")); // incorrect date format
+        assertFalse(Record.isValidDateFormat("10 Jul 2022 1000")); // incorrect date format
+        assertFalse(Record.isValidDateFormat("12 12 2007 1230")); // incorrect date format
+        assertFalse(Record.isValidDateFormat("2004-11-11 1300")); // incorrect date format
+        assertFalse(Record.isValidDateFormat("01-01-2001")); // missing time
+        assertFalse(Record.isValidDateFormat("01-01-2001 3000")); // invalid time
+
+        // valid dates
+        assertTrue(Record.isValidDateFormat("01-01-2001 1200"));
+        assertTrue(Record.isValidDateFormat("12-02-1927 1230"));
+        assertTrue(Record.isValidDateFormat("31-12-2003 1300"));
+    }
+
+    @Test
+    void isFutureDate() {
+        assertTrue(Record.isFutureDate(LocalDateTime.now().plusYears(10).format(DATE_FORMAT)));
+        assertTrue(Record.isFutureDate(LocalDateTime.now().plusDays(1).format(DATE_FORMAT)));
+        assertTrue(Record.isFutureDate(LocalDateTime.now().plusHours(1).format(DATE_FORMAT)));
+
+        assertFalse(Record.isFutureDate(LocalDateTime.now().minusYears(6).format(DATE_FORMAT)));
+        assertFalse(Record.isFutureDate(LocalDateTime.now().minusDays(1).format(DATE_FORMAT)));
+        assertFalse(Record.isFutureDate(LocalDateTime.now().minusHours(1).format(DATE_FORMAT)));
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -70,7 +70,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_BIRTHDATE, VALID_PHONE, VALID_EMAIL,
                         VALID_ADDRESS, VALID_TAGS, VALID_RECORDLIST, VALID_APPOINTMENT);
-        String expectedMessage = Birthdate.MESSAGE_CONSTRAINTS;
+        String expectedMessage = Birthdate.MESSAGE_INVALID_DATE_FORMAT;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Birthdate;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.record.Record;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -140,7 +141,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_BIRTHDATE, VALID_PHONE, VALID_EMAIL,
                         VALID_ADDRESS, VALID_TAGS, invalidRecords, VALID_APPOINTMENT);
-        String expectedMessage = Messages.MESSAGE_INVALID_DATE_FORMAT;
+        String expectedMessage = Record.MESSAGE_INVALID_DATE_FORMAT;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthdate;


### PR DESCRIPTION
- Add `Record#isFutureDate()` and `Birthdate#isFutureDate()`.
- Show different error messages when date is in *incorrect format* or *after current date*.
- Update test cases in `RecordTest` and `BirthdateTest` to reflect changes.